### PR TITLE
Add MergeHtmlDocs function to HtmlDocHelper class

### DIFF
--- a/HtmlDocoumentTest/UnitTest1.cs
+++ b/HtmlDocoumentTest/UnitTest1.cs
@@ -72,4 +72,16 @@ public class Tests
         string test = "<div><li></li></ci><raw></raw><xml></xml></div>";
         Assert.That(HtmlDocHelper.ContainsTextNodePredicted(test), Is.False);
     }
+
+    [Test]
+    public void Test_MergeHtmlDocs()
+    {
+        string htmlDoc1 = "<html><body><div class='container'><p id='paragraph1'>Hello</p></div></body></html>";
+        string htmlDoc2 = "<html><body><div class='container'><p id='paragraph2'>World</p></div><footer>Footer content</footer></body></html>";
+        string expectedMergedHtml = "<html><body><div class='container'><p id='paragraph1'>Hello</p><p id='paragraph2'>World</p></div><footer>Footer content</footer></body></html>";
+
+        string mergedHtml = HtmlDocHelper.MergeHtmlDocs(htmlDoc1, htmlDoc2);
+
+        Assert.That(mergedHtml, Is.EqualTo(expectedMergedHtml));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -20,3 +20,28 @@ https://stackoverflow.com/questions/9484879/graphviz-doxygen-to-generate-uml-cla
 # Citaiton Machine
 
 https://www.scribbr.com/citation/generator/folders/2SW3rWl9aNisXzPZg9dKY9/lists/2LRvxShvLPGS5BKYE6nno4/
+
+# MergeHtmlDocs Function
+
+The `MergeHtmlDocs` function in the `HtmlDocHelper` class allows you to merge two HTML documents without duplicating any nodes. This function ensures that the resulting merged document contains all unique nodes from both input documents.
+
+## Usage
+
+To use the `MergeHtmlDocs` function, follow these steps:
+
+1. Ensure you have the `HtmlDocHelper` class available in your project.
+2. Call the `MergeHtmlDocs` function with two HTML document strings as parameters.
+3. The function will return the merged HTML document as a string.
+
+## Example
+
+```csharp
+string htmlDoc1 = "<html><body><div class='container'><p id='paragraph1'>Hello</p></div></body></html>";
+string htmlDoc2 = "<html><body><div class='container'><p id='paragraph2'>World</p></div><footer>Footer content</footer></body></html>";
+
+string mergedHtml = HtmlDocHelper.MergeHtmlDocs(htmlDoc1, htmlDoc2);
+
+Console.WriteLine(mergedHtml);
+```
+
+In this example, the `MergeHtmlDocs` function merges the two input HTML documents and returns the merged result. The resulting merged HTML document will contain all unique nodes from both input documents.

--- a/convert_to_markdown_bullets.py
+++ b/convert_to_markdown_bullets.py
@@ -20,6 +20,30 @@ def convert_to_markdown_bullets(text):
     
     return '\n'.join(markdown_lines)
 
+
+def convert_text_to_markdown(input_text):
+    """
+    Converts text-based bullet points into Markdown bullet points.
+    
+    Parameters:
+    input_text (str): The input text containing bullet points.
+    
+    Returns:
+    str: The converted text with Markdown bullet points.
+    """
+    lines = input_text.split('\n')
+    markdown_lines = []
+
+    for line in lines:
+        stripped_line = line.strip()
+        if stripped_line and not stripped_line.startswith('- '):
+            markdown_lines.append(f"- {stripped_line}")
+        else:
+            markdown_lines.append(line)
+    
+    return '\n'.join(markdown_lines)
+
+
 # Example usage
 input_text = """First point
 Second point


### PR DESCRIPTION
Add new functions and unit tests for HTML document merging and Markdown conversion.

* **convert_to_markdown_bullets.py**
  - Add `convert_text_to_markdown` function to convert text-based bullet points into Markdown bullet points.

* **HtmlDocoumentTest/UnitTest1.cs**
  - Add unit test `Test_MergeHtmlDocs` for the `MergeHtmlDocs` function in the `HtmlDocHelper` class.

* **Shared/HtmlDocHelper.cs**
  - Add `MergeHtmlDocs` function to merge two HTML documents without duplicating any nodes.
  - Add helper functions `MergeNodes`, `FindMatchingNode`, and `NodesAreSimilar` to support the merging process.

* **README.md**
  - Add documentation for the `MergeHtmlDocs` function, including usage instructions and an example.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/DocumentGenerator/pull/1?shareId=ed5f6ca6-0a69-4e15-8e13-4112e1738114).