### PR TITLE
Create 上下文.md

### DIFF
--- a/IO/上下文.md
+++ b/IO/上下文.md
@@ -1,0 +1,50 @@
+# 上下文
+
+The term **context** is used in different ways in **Natural Language Processing (NLP)** and **Automata Theory**, though both involve structured interpretation of sequences.
+
+---
+
+### 1. **Context in NLP**
+In **NLP**, context refers to the **linguistic environment** in which a word, phrase, or sentence appears, affecting its meaning and interpretation. There are several types of context:
+
+- **Lexical Context**: The surrounding words influence the meaning of a word (e.g., "bank" in "river bank" vs. "money bank").
+- **Syntactic Context**: The grammatical structure affects interpretation (e.g., "He saw her duck" – is "duck" a verb or noun?).
+- **Semantic Context**: The broader meaning influences interpretation (e.g., "He played the **bass**" – is it a fish or a musical instrument?).
+- **Pragmatic Context**: Real-world knowledge, discourse history, and speaker intentions shape meaning (e.g., "Can you pass the salt?" is a request, not a yes/no question).
+- **Historical Context**: Previous words or sentences influence the current interpretation (e.g., in chatbots, the meaning of "it" depends on prior dialogue).
+
+NLP models (like **transformers** in GPT or BERT) use mechanisms such as **attention** to capture long-range dependencies within context.
+
+---
+
+### 2. **Context in Automata Theory**
+In **Automata Theory**, context refers to **formal language constraints** in computational models:
+
+- **Context in Regular Languages (Finite Automata)**:
+  - Finite State Machines (FSMs) process input based on a **limited context**, meaning they only consider the **current state** and **next symbol** without memory of long-range dependencies.
+  
+- **Context in Context-Free Grammars (CFGs) & Pushdown Automata (PDA)**:
+  - Context-Free Grammars allow structures like nested parentheses `(a (b c) d)` but still lack full memory.
+  - Pushdown Automata have a **stack** that helps handle a limited form of context (e.g., balanced parentheses).
+
+- **Context in Context-Sensitive Grammars (CSGs) & Linear Bounded Automata (LBA)**:
+  - In **Context-Sensitive Grammars**, the production rules depend on surrounding symbols (e.g., transformation `A → B` might only occur if preceded by `X`).
+  - **Linear Bounded Automata (LBA)** extend finite automata with a bounded tape, allowing processing that depends on more context.
+
+- **Context in Turing Machines**:
+  - A **Turing Machine** has an **unbounded tape**, meaning it can store and retrieve **any amount of contextual information** during computation, making it the most powerful model.
+
+---
+
+### **Key Differences**
+| Feature | Context in NLP | Context in Automata Theory |
+|---------|---------------|----------------------------|
+| **Definition** | Linguistic environment that affects meaning | Constraints affecting language processing rules |
+| **Scope** | Local (word-level) to global (discourse-level) | Local (state transitions) to global (full computation history) |
+| **Memory** | Transformer models use attention and embeddings | Automata models range from no memory (FSM) to full memory (Turing Machine) |
+| **Flexibility** | Probabilistic and variable-length context handling | Deterministic or bounded memory in most cases |
+| **Example** | "Apple" means different things in different contexts | In a PDA, `A → B` transformation might depend on stack contents |
+
+In **NLP**, context is fluid and ambiguous, requiring **probabilistic models**. In **Automata Theory**, context is **formally defined** through **rules and constraints** in grammars and machines.
+
+Would you like a deeper analysis on a specific aspect?


### PR DESCRIPTION
# 上下文

The term **context** is used in different ways in **Natural Language Processing (NLP)** and **Automata Theory**, though both involve structured interpretation of sequences.

---

### 1. **Context in NLP**
In **NLP**, context refers to the **linguistic environment** in which a word, phrase, or sentence appears, affecting its meaning and interpretation. There are several types of context:

- **Lexical Context**: The surrounding words influence the meaning of a word (e.g., "bank" in "river bank" vs. "money bank").
- **Syntactic Context**: The grammatical structure affects interpretation (e.g., "He saw her duck" – is "duck" a verb or noun?).
- **Semantic Context**: The broader meaning influences interpretation (e.g., "He played the **bass**" – is it a fish or a musical instrument?).
- **Pragmatic Context**: Real-world knowledge, discourse history, and speaker intentions shape meaning (e.g., "Can you pass the salt?" is a request, not a yes/no question).
- **Historical Context**: Previous words or sentences influence the current interpretation (e.g., in chatbots, the meaning of "it" depends on prior dialogue).

NLP models (like **transformers** in GPT or BERT) use mechanisms such as **attention** to capture long-range dependencies within context.

---

### 2. **Context in Automata Theory**
In **Automata Theory**, context refers to **formal language constraints** in computational models:

- **Context in Regular Languages (Finite Automata)**:
  - Finite State Machines (FSMs) process input based on a **limited context**, meaning they only consider the **current state** and **next symbol** without memory of long-range dependencies.
  
- **Context in Context-Free Grammars (CFGs) & Pushdown Automata (PDA)**:
  - Context-Free Grammars allow structures like nested parentheses `(a (b c) d)` but still lack full memory.
  - Pushdown Automata have a **stack** that helps handle a limited form of context (e.g., balanced parentheses).

- **Context in Context-Sensitive Grammars (CSGs) & Linear Bounded Automata (LBA)**:
  - In **Context-Sensitive Grammars**, the production rules depend on surrounding symbols (e.g., transformation `A → B` might only occur if preceded by `X`).
  - **Linear Bounded Automata (LBA)** extend finite automata with a bounded tape, allowing processing that depends on more context.

- **Context in Turing Machines**:
  - A **Turing Machine** has an **unbounded tape**, meaning it can store and retrieve **any amount of contextual information** during computation, making it the most powerful model.

---

### **Key Differences**
| Feature | Context in NLP | Context in Automata Theory | |---------|---------------|----------------------------| | **Definition** | Linguistic environment that affects meaning | Constraints affecting language processing rules | | **Scope** | Local (word-level) to global (discourse-level) | Local (state transitions) to global (full computation history) | | **Memory** | Transformer models use attention and embeddings | Automata models range from no memory (FSM) to full memory (Turing Machine) | | **Flexibility** | Probabilistic and variable-length context handling | Deterministic or bounded memory in most cases | | **Example** | "Apple" means different things in different contexts | In a PDA, `A → B` transformation might depend on stack contents |

In **NLP**, context is fluid and ambiguous, requiring **probabilistic models**. In **Automata Theory**, context is **formally defined** through **rules and constraints** in grammars and machines.

Would you like a deeper analysis on a specific aspect?